### PR TITLE
Fix version conflicts caused by PR#109

### DIFF
--- a/src/Microservice.Whatevers.Repositories/Microservice.Whatevers.Repositories.csproj
+++ b/src/Microservice.Whatevers.Repositories/Microservice.Whatevers.Repositories.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />    
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.7" />

--- a/test/Microservice.Whatevers.Domain.UnitTest/Microservice.Whatevers.Domain.UnitTest.csproj
+++ b/test/Microservice.Whatevers.Domain.UnitTest/Microservice.Whatevers.Domain.UnitTest.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2020.3.4" />
+        <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2021.1.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump JetBrains.dotCover.CommandLineTools from 2020.3.4 to 2021.1.4. [(PR#109)](https://github.com/AntonioFalcao/Microservice.Whatevers/pull/109).
Hope this fix can help you.

Best regards,
sucrose